### PR TITLE
Adding explicit type conversion to overloaded log function

### DIFF
--- a/TESTS/block_device/i2cee/main.cpp
+++ b/TESTS/block_device/i2cee/main.cpp
@@ -50,7 +50,7 @@ void test_read_write() {
     uint8_t *write_block = new uint8_t[block_size];
     uint8_t *read_block = new uint8_t[block_size];
     uint8_t *error_mask = new uint8_t[TEST_ERROR_MASK];
-    unsigned addrwidth = ceil(log(bd.size()-1) / log(16))+1;
+    unsigned addrwidth = ceil(log(float(bd.size()-1)) / log(float(16)))+1;
 
     for (int b = 0; b < TEST_BLOCK_COUNT; b++) {
         // Find a random block


### PR DESCRIPTION
As ARMCC fails to compile for the log function:

![overloaded_log](https://cloud.githubusercontent.com/assets/17567812/24161301/ecb4d36a-0e5b-11e7-9734-ced97376123f.jpg)

Adding an explicit type conversion to float to fix for ARMCC. Also Greentea tested with GCC and IAR compilers for CI test shield and FRDM_K64F. Logs attached below:

mbed test -t ARM -m K64F -n i2ceeprom-driver-tests-block_device-i2cee 2>&1 | tee ARMCC_build_log.txt
[ARMCC_build_log.txt](https://github.com/ARMmbed/i2ceeprom-driver/files/859109/ARMCC_build_log.txt)

mbed test -t GCC_ARM -m K64F -n i2ceeprom-driver-tests-block_device-i2cee 2>&1 | tee GCC_build_log.txt
[GCC_build_log.txt](https://github.com/ARMmbed/i2ceeprom-driver/files/859117/GCC_build_log.txt)

mbed test -t IAR -m K64F -n i2ceeprom-driver-tests-block_device-i2cee 2>&1 | tee IAR_build_log.txt
[IAR_build_log.txt](https://github.com/ARMmbed/i2ceeprom-driver/files/859119/IAR_build_log.txt)

