### PR TITLE
Fix .travis.yml requirements install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ install:
       # Get dependencies
     - git clone https://github.com/armmbed/mbed-os.git
       # Install python dependencies
-    - sudo pip install -r mbed-os/requirements.txt
+    - pip install -r mbed-os/requirements.txt


### PR DESCRIPTION
Recently, how pip installs dependencies in travis has changed.
Now, installing dependecies with sudo prevents import in user space.