### PR TITLE
add missing get_type() from BlockDevice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,19 @@
+dist: xenial
+language: python
+python: 2.7
+
+install:
+      # Get arm-none-eabi-gcc
+    - sudo add-apt-repository -y ppa:team-gcc-arm-embedded/ppa
+    - sudo apt-get update -qq
+    - sudo apt-get install -qq gcc-arm-embedded
+      # Get dependencies
+    - git clone https://github.com/armmbed/mbed-os.git
+      # Install python dependencies
+#    - python -m pip install --upgrade pip==18.1
+#    - python -m pip install --upgrade setuptools==40.4.3
+    - pip install -r mbed-os/requirements.txt
+
 script:
       # Check that examples compile
     - sed -n '/``` cpp/,${/```$/q;/```/d;p}' README.md > main.cpp &&
@@ -8,21 +24,3 @@ script:
       PYTHONPATH=mbed-os python mbed-os/tools/make.py -t GCC_ARM -m K82F
           --source=. --build=BUILD/K82F/GCC_ARM -j0 &&
       rm main.cpp
-
-      # Check that tests compile
-    - rm -r BUILD && PYTHONPATH=mbed-os python mbed-os/tools/test.py
-          -t GCC_ARM -m K82F --source=. --build=BUILD/TESTS/K82F/GCC_ARM -j0
-          -n tests*
-
-python:
-    - "2.7"
-
-install:
-      # Get arm-none-eabi-gcc
-    - sudo add-apt-repository -y ppa:terry.guo/gcc-arm-embedded
-    - sudo apt-get update -qq
-    - sudo apt-get install -qq gcc-arm-none-eabi --force-yes
-      # Get dependencies
-    - git clone https://github.com/armmbed/mbed-os.git
-      # Install python dependencies
-    - sudo pip install -r mbed-os/requirements.txt

--- a/I2CEEBlockDevice.cpp
+++ b/I2CEEBlockDevice.cpp
@@ -147,3 +147,8 @@ bd_size_t I2CEEBlockDevice::size() const
 {
     return _size;
 }
+
+const char *I2CEEBlockDevice::get_type() const
+{
+    return "I2CEE";
+}

--- a/I2CEEBlockDevice.h
+++ b/I2CEEBlockDevice.h
@@ -156,6 +156,12 @@ public:
      *  @return         Size of the underlying device in bytes
      */
     virtual bd_size_t size() const;
+
+    /** Get the BlockDevice class type.
+     *
+     *  @return         A string representation of the BlockDevice class type.
+     */
+    virtual const char *get_type() const;
     
 private:
     I2C * _i2c;

--- a/I2CEEBlockDevice.h
+++ b/I2CEEBlockDevice.h
@@ -16,7 +16,7 @@
 #ifndef MBED_I2CEEPROM_BLOCK_DEVICE_H
 #define MBED_I2CEEPROM_BLOCK_DEVICE_H
  
-#include <mbed.h>
+#include "mbed.h"
 #include "BlockDevice.h"
 
  


### PR DESCRIPTION
according to [this page](https://github.com/ARMmbed/mbed-os/blob/master/docs/design-documents/features/storage/BlockDevices/get_type_method.md) it should have a function `get_type()` but i think this repo should be merged into OS as all other blockdevices are and `I2CEE` return should be added to above page as well