### PR TITLE
Remove the deprecated wait API usage

### DIFF
--- a/I2CEEBlockDevice.cpp
+++ b/I2CEEBlockDevice.cpp
@@ -122,7 +122,7 @@ int I2CEEBlockDevice::_sync()
             return 0;
         }
 
-        wait_ms(1);
+        thread_sleep_for(1);
     }
 
     return BD_ERROR_DEVICE_ERROR;


### PR DESCRIPTION
`wait` and `wait_ms` are removed from Mbed OS source in the [PR#12572](https://github.com/ARMmbed/mbed-os/pull/12572), so modified source to use thread_sleep_for API.

### Reviewers <!-- Optional -->
@evedon,  @jamesbeyond